### PR TITLE
Fix package version bug and add auto ip

### DIFF
--- a/DataCollectors/README.md
+++ b/DataCollectors/README.md
@@ -12,7 +12,7 @@ Data collectors are just regular python functions that will generate the notific
 ```
 
 The elements represent the following:
-- Element 0: a bool that says if the message is valid or not (`True|False`)
+- Element 0: a bool that says if the message should be sent or not (`True|False`)
 - Element 1: a string that represents the message's title
 - Element 2: a string that represents the message's body
 

--- a/DataCollectors/UpdatesAvailableCollector.py
+++ b/DataCollectors/UpdatesAvailableCollector.py
@@ -66,8 +66,12 @@ def updates_available_collector(temp_directory: str, debug: bool):
                 if dep_ver_installed:
                     continue
 
+                candidate_ver = dep_cache.get_candidate_ver(target_pkg)
+                if candidate_ver == None:
+                    continue
+
                 # Add the dependency as part of the updates list
-                ver_str = dep_cache.get_candidate_ver(target_pkg).ver_str
+                ver_str = candidate_ver.ver_str
                 package_name = "Package name: " + target_pkg.name + "\n"
                 package_curr_ver = "  Current installed version: " + ver_str + "\n"
                 package_update_ver = "  Newer version available: " + ver_str + "\n"

--- a/OMVPushNotifications.py
+++ b/OMVPushNotifications.py
@@ -94,6 +94,8 @@ def parse_config_file(config_file_path):
                 curr_omv_system = omv_systems[-1]
                 good_omv_config = curr_omv_system["hostname"] != "" and curr_omv_system["domain-name"] != ""
                 if not good_omv_config:
+                    if curr_omv_system["ip"] == "":
+                        curr_omv_system["ip"] = Utils().get_system_ip_address()
                     good_omv_config = curr_omv_system["ip"] != ""
                 if not good_omv_config:
                     config_file.close()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Author: Axel Y. Rivera <br />
 Email: axelrivera1986@gmail.com <br />
-Version: 2023.05.21
+Version: 2024.11.23
 
 ## Summary
 
@@ -10,6 +10,9 @@ OMV push notifications is a tool for collecting data from the OS, parse and send
 
 ## Release notes:
 
+- 2024.11.23:
+    * Fixed issue when package version is not vailable and produced a `None` check failure.
+    * Added feature to automatically collect the IP address from the system if the IP and hostname aren't provided.
 - 2023.05.21:
     * Replaced data collectors registry with a new section in config file called collector. Check the [README file](/DataCollectors/README.md) for data collectors to understand the new format.
     * Fixed a bug in the updates available collector when dependicies weren't available.
@@ -94,11 +97,11 @@ The basic idea is to keep things as simple as possible (I hope it is simple for 
 
     - `omv-system-address` : Section for the information related to the OMV system network
         - `name` : Preferred name for the current network configuration (**default value is `OMV-#`**)
-        - `hostname` : Host name of your OMV system (**required if `ip` is not provided**)
-        - `domain` : Domain of your OMV system (**required if `ip` is not provided**)
+        - `hostname` : Host name of your OMV system
+        - `domain` : Domain of your OMV system
         - `web-protocol` : Web protocol used to access the web interface (**default value is `http`**)
         - `port` : Port used to access OMV web interface (**default value is `80`**)
-        - `ip` : IP address of your OMV system (**required if `hostname` and `domain` are not provided**)
+        - `ip` : IP address of your OMV system
 
     - `collector` : Section for handling a data collector (**name required**)
         - `parameter 1` : Parameter and value for the collecter (**required**)
@@ -134,7 +137,7 @@ The implementation of OMV push notifications interface is pretty simple. The bas
 
 ## Notes:
 
-There is no warranties using this tool. Also, this is **NOT** an official tool, plugin, package, or application from OpenMediaVault, Simplepush or its communities. This interface is a simple tool I developed as a side project. Feel free to contact me if you need help with it.
+There is no warranties using this tool. Also, this is **NOT** an official tool, plugin, package, or application from OpenMediaVault, Simplepush or related communities. This interface is a simple tool I developed as a side project. Feel free to contact me if you need help with it, or submit a GitHub issue.
 
 ## TODO:
 1. Add an extra parameter to the temperature collector for collecting other temperatures like HDD.

--- a/Utils.py
+++ b/Utils.py
@@ -1,4 +1,5 @@
 import time
+import socket
 
 # Class that handles helper functions
 class Utils:
@@ -94,3 +95,9 @@ class Utils:
         collectors_available = ["temperature_collector", "updates_available_collector", "disk_space_collector"]
         return collectors_available
 
+    def get_system_ip_address(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('10.0.0.0', 0))
+        ip_addrs = s.getsockname()[0]
+        s.close()
+        return ip_addrs


### PR DESCRIPTION
This patch fixes a bug when trying to collect the version of a package and it doesn't exist. Also, it adds a feature for collecting the IP address automatically from the system if it isn't provided in the config file.